### PR TITLE
Set `updateDelegate` when a provider invalidates

### DIFF
--- a/Sources/Composed/Core/SectionProviderMapping.swift
+++ b/Sources/Composed/Core/SectionProviderMapping.swift
@@ -193,6 +193,7 @@ public final class SectionProviderMapping: SectionProviderUpdateDelegate, Sectio
 
     public func invalidateAll(_ provider: SectionProvider) {
         delegate?.mappingDidInvalidate(self)
+        provider.sections.forEach { $0.updateDelegate = self }
     }
 
     public func willBeginUpdating(_ section: Section) {

--- a/Tests/ComposedTests/SegmentedSectionProvider.swift
+++ b/Tests/ComposedTests/SegmentedSectionProvider.swift
@@ -1,0 +1,59 @@
+import Quick
+import Nimble
+import UIKit
+
+@testable import Composed
+
+final class SegmentedSectionProvider_Spec: QuickSpec {
+
+    override func spec() {
+        describe("SegmentedSectionProvider") {
+            var global: SegmentedSectionProvider!
+            var mapping: SectionProviderMapping!
+            var child1: ComposedSectionProvider!
+            var child2: ArraySection<String>!
+
+            beforeEach {
+                global = SegmentedSectionProvider()
+                mapping = SectionProviderMapping(provider: global)
+
+                child1 = ComposedSectionProvider()
+                    let child1a = ArraySection<String>()
+                    let child1b = ArraySection<String>()
+                child2 = ArraySection<String>()
+
+                global.append(child1)
+                global.append(child2)
+
+                child1.append(child1a)
+                child1.append(child1b)
+            }
+
+            context("after changing the `currentIndex") {
+                beforeEach {
+                    global.currentIndex = 1
+                }
+
+                it("should unset the delegate of the previous child") {
+                    expect(child1.updateDelegate).to(beNil())
+                }
+
+                it("should set the delegate of the current child") {
+                    expect(child2.updateDelegate).toNot(beNil())
+                }
+            }
+
+            context("without changing the `currentIndex`") {
+                it("should set the delegate") {
+                    expect(child1.updateDelegate).toNot(beNil())
+                }
+
+                it("should not set the delegate of children") {
+                    expect(child2.updateDelegate).to(beNil())
+                }
+
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Basic `Section`s were not propagating updates if added via a call to `invalidateAll`. This is to address #2.

The issue can be recreated by using a `SegmentedSectionProvider` when switching to a segment that contains a `Section` (`SectionProvider` works I _think_)

This commit alone is likely not enough to fix this issue; `updateDelegate` should probably be set to `nil` for removed `Section`s, and should probably be set in more places.