### PR TITLE
Mark `updateDelegate`s as `weak`

### DIFF
--- a/Sources/Composed/Providers/ComposedSectionProvider.swift
+++ b/Sources/Composed/Providers/ComposedSectionProvider.swift
@@ -27,7 +27,7 @@ open class ComposedSectionProvider: AggregateSectionProvider, SectionProviderUpd
         }
     }
 
-    open var updateDelegate: SectionProviderUpdateDelegate?
+    open weak var updateDelegate: SectionProviderUpdateDelegate?
 
     /// Represents all of the children this provider contains
     private var children: [Child] = []

--- a/Sources/Composed/Providers/SegmentedSectionProvider.swift
+++ b/Sources/Composed/Providers/SegmentedSectionProvider.swift
@@ -28,7 +28,7 @@ open class SegmentedSectionProvider: AggregateSectionProvider, SectionProviderUp
         }
     }
 
-    open var updateDelegate: SectionProviderUpdateDelegate?
+    open weak var updateDelegate: SectionProviderUpdateDelegate?
 
     /// Represents all of the children this provider contains
     private var children: [Child] = []

--- a/Sources/Composed/Sections/ManagedSection.swift
+++ b/Sources/Composed/Sections/ManagedSection.swift
@@ -23,7 +23,7 @@ open class ManagedSection<Element>: NSObject, NSFetchedResultsControllerDelegate
     /// Returns the `NSManagedObjectContext` associated with this section
     public let managedObjectContext: NSManagedObjectContext
 
-    public var updateDelegate: SectionUpdateDelegate?
+    public weak var updateDelegate: SectionUpdateDelegate?
 
     // The current controller that will return elements
     private var fetchedResultsController: NSFetchedResultsController<Element>?

--- a/Sources/Composed/Sections/SingleElementSection.swift
+++ b/Sources/Composed/Sections/SingleElementSection.swift
@@ -13,7 +13,7 @@ import Foundation
  */
 open class SingleElementSection<Element>: Section {
 
-    public var updateDelegate: SectionUpdateDelegate?
+    public weak var updateDelegate: SectionUpdateDelegate?
 
     /// Returns the element
     public private(set) var element: Element


### PR DESCRIPTION
`ArraySection.updateDelegate` was already weak and looking at the memory graph this is causing circular references