### PR TITLE
Fix compilation of tests

### DIFF
--- a/Tests/ComposedTests/SectionProviderDelegate+Spec.swift
+++ b/Tests/ComposedTests/SectionProviderDelegate+Spec.swift
@@ -47,6 +47,13 @@ final class SectionProviderDelegate_Spec: QuickSpec {
 }
 
 final class MockDelegate: SectionProviderUpdateDelegate {
+    func willBeginUpdating(_ provider: SectionProvider) {
+
+    }
+
+    func didEndUpdating(_ provider: SectionProvider) {
+        
+    }
 
     func invalidateAll(_ provider: SectionProvider) {
 

--- a/Tests/ComposedTests/SectionProviderMapper+Spec.swift
+++ b/Tests/ComposedTests/SectionProviderMapper+Spec.swift
@@ -163,4 +163,8 @@ final class MockSectionProviderMappingDelegate: SectionProviderMappingDelegate {
     func mapping(_ mapping: SectionProviderMapping, select indexPath: IndexPath) { }
     func mapping(_ mapping: SectionProviderMapping, deselect indexPath: IndexPath) { }
 
+    func mappingDidEndUpdating(_ mapping: SectionProviderMapping) {}
+    func mappingDidInvalidate(_ mapping: SectionProviderMapping) {}
+    func mapping(_ mapping: SectionProviderMapping, move sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {}
+
 }


### PR DESCRIPTION
It looks like there's been a breaking API change compared to 1.0.1, albeit a small one.