### PR TITLE
ComposedSectionProvider fixes

### DIFF
--- a/Sources/Composed/Providers/ComposedSectionProvider.swift
+++ b/Sources/Composed/Providers/ComposedSectionProvider.swift
@@ -191,18 +191,21 @@ open class ComposedSectionProvider: AggregateSectionProvider, SectionProviderUpd
     public func remove(at index: Int) {
         guard children.indices.contains(index) else { return }
         let child = children[index]
-        var sections: [Section] = []
+        let sections: [Section]
+        let sectionOffset: Int
 
         switch child {
         case let .section(child):
-            sections.append(child)
+            sections = [child]
+            sectionOffset = self.sectionOffset(for: child)
         case let .provider(child):
             child.updateDelegate = nil
-            sections.append(contentsOf: child.sections)
+            sectionOffset = self.sectionOffset(for: child)
+            sections = child.sections
         }
 
-        let firstIndex = index
-        let endIndex = index + sections.count
+        let firstIndex = sectionOffset
+        let endIndex = sectionOffset + sections.count
 
         updateDelegate?.willBeginUpdating(self)
         children.remove(at: index)

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import Foundation
 
 @testable import Composed
 
@@ -52,7 +53,54 @@ final class ComposedSectionProvider_Spec: QuickSpec {
                 expect(child2.sectionOffset(for: child2z)) == 2
                 expect(child2.sectionOffset(for: child2e)) == 3
             }
+
+            context("when a section is inserted after a section provider with multiple sections") {
+                var mockDelegate: MockSectionProviderUpdateDelegate!
+                var countBefore: Int!
+
+                beforeEach {
+                    mockDelegate = MockSectionProviderUpdateDelegate()
+                    global.updateDelegate = mockDelegate
+
+                    let newSection = ArraySection<String>()
+                    countBefore = global.numberOfSections
+
+                    global.append(newSection)
+                }
+
+                it("should pass the correct indexes to the delegate") {
+                    expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(integer: countBefore)
+                }
+            }
         }
     }
 
+}
+
+private final class MockSectionProviderUpdateDelegate: SectionProviderUpdateDelegate {
+    private(set) var willBeginUpdatingCalls: [SectionProvider] = []
+    private(set) var didEndUpdatingCalls: [SectionProvider] = []
+    private(set) var invalidateAllCalls: [SectionProvider] = []
+    private(set) var didInsertSectionsCalls: [(SectionProvider, [Section], IndexSet)] = []
+    private(set) var didRemoveSectionsCalls: [(SectionProvider, [Section], IndexSet)] = []
+
+    func willBeginUpdating(_ provider: SectionProvider) {
+        willBeginUpdatingCalls.append(provider)
+    }
+
+    func didEndUpdating(_ provider: SectionProvider) {
+        didEndUpdatingCalls.append(provider)
+    }
+
+    func invalidateAll(_ provider: SectionProvider) {
+        invalidateAllCalls.append(provider)
+    }
+
+    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet) {
+        didInsertSectionsCalls.append((provider, sections, indexes))
+    }
+
+    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet) {
+        didRemoveSectionsCalls.append((provider, sections, indexes))
+    }
 }

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -112,7 +112,7 @@ final class ComposedSectionProvider_Spec: QuickSpec {
                 }
 
                 it("should pass the correct indexes to the delegate") {
-                    expect(mockDelegate.didRemoveSectionsCalls.last!.2) == IndexSet(integer: countBefore)
+                    expect(mockDelegate.didRemoveSectionsCalls.last!.2) == IndexSet(integer: countBefore - 1)
                 }
             }
         }

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -94,6 +94,27 @@ final class ComposedSectionProvider_Spec: QuickSpec {
                     expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(integersIn: countBefore..<(countBefore + sectionProvider.numberOfSections))
                 }
             }
+
+            context("when a section located after a section provider with multiple sections is removed") {
+                var mockDelegate: MockSectionProviderUpdateDelegate!
+                var countBefore: Int!
+
+                beforeEach {
+                    mockDelegate = MockSectionProviderUpdateDelegate()
+                    global.updateDelegate = mockDelegate
+
+                    let newSection = ArraySection<String>()
+                    global.append(newSection)
+
+                    countBefore = global.numberOfSections
+
+                    global.remove(newSection)
+                }
+
+                it("should pass the correct indexes to the delegate") {
+                    expect(mockDelegate.didRemoveSectionsCalls.last!.2) == IndexSet(integer: countBefore)
+                }
+            }
         }
     }
 

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -91,7 +91,7 @@ final class ComposedSectionProvider_Spec: QuickSpec {
                 }
 
                 it("should pass the correct indexes to the delegate") {
-                    expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(IndexSet(integersIn: countBefore..<(countBefore + sectionProvider.numberOfSections)))
+                    expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(integersIn: countBefore..<(countBefore + sectionProvider.numberOfSections))
                 }
             }
         }

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -72,6 +72,28 @@ final class ComposedSectionProvider_Spec: QuickSpec {
                     expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(integer: countBefore)
                 }
             }
+
+            context("when a section provider is inserted after a section provider with multiple sections") {
+                var mockDelegate: MockSectionProviderUpdateDelegate!
+                var countBefore: Int!
+                var sectionProvider: ComposedSectionProvider!
+
+                beforeEach {
+                    mockDelegate = MockSectionProviderUpdateDelegate()
+                    global.updateDelegate = mockDelegate
+                    sectionProvider = ComposedSectionProvider()
+                    sectionProvider.append(ArraySection<String>())
+                    sectionProvider.append(ArraySection<String>())
+
+                    countBefore = global.numberOfSections
+
+                    global.append(sectionProvider)
+                }
+
+                it("should pass the correct indexes to the delegate") {
+                    expect(mockDelegate.didInsertSectionsCalls.last!.2) == IndexSet(IndexSet(integersIn: countBefore..<(countBefore + sectionProvider.numberOfSections)))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
These were quite hard to track down since the errors that would occur would often be visual and not a crash, although in some scenarios it did seem to trigger a crash.

I think this highlights the need for a much larger test suite.

# Sidebar

It also made me question the `insert(_:at:)` functions because it's not really clear what the `index` is. Should it insert it at the index in the context of the sections and providers (as it does now), or just sections?

For example, with:

- Section A
- Section Provider
  - Section B
  - Section C
- Section D
- Section E

If I insert a section at index 3 should it look like:

- Section A
- Section Provider
  - Section B
  - Section C
- New Section
- Section D
- Section E

or

- Section A
- Section Provider
  - Section B
  - Section C
- Section D
- New Section
- Section E

