### PR TITLE
Rewrite delegates to take perform update closures

### DIFF
--- a/Sources/Composed/Core/Section.swift
+++ b/Sources/Composed/Core/Section.swift
@@ -21,6 +21,9 @@ public extension Section {
 
 /// A delegate that will respond to update events from a `Section`
 public protocol SectionUpdateDelegate: class {
+    /// A closure that will be called synchronously on the main thread. It must perform the updates
+    /// associated with the mapping change before returning.
+    typealias UpdatePerformer = () -> Void
 
     /// Notifies the delegate before a section will process updates
     /// - Parameter section: The section that will be updated
@@ -32,32 +35,50 @@ public protocol SectionUpdateDelegate: class {
 
     /// Notifies the delegate that all sections should be invalidated, ignoring individual updates
     /// - Parameter section: The section that requested the invalidation
-    func invalidateAll(_ section: Section)
+    func invalidateAll(_ section: Section, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that an element was inserted
     /// - Parameters:
     ///   - section: The section where the insert occurred
     ///   - index: The index of the element that was inserted
-    func section(_ section: Section, didInsertElementAt index: Int)
+    func section(_ section: Section, didInsertElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that an element was inserted
+    /// - Parameters:
+    ///   - section: The section where the insert occurred
+    ///   - index: The index of the element that was inserted
+    func section(_ section: Section, didInsertElementsAt indexSet: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that an element was removed
     /// - Parameters:
     ///   - section: The section where the remove occurred
     ///   - index: The index of the element that was removed
-    func section(_ section: Section, didRemoveElementAt index: Int)
+    func section(_ section: Section, didRemoveElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that an element was removed
+    /// - Parameters:
+    ///   - section: The section where the remove occurred
+    ///   - index: The index of the element that was removed
+    func section(_ section: Section, didRemoveElementsAt indexSet: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that an element was updated
     /// - Parameters:
     ///   - section: The section where the update occurred
     ///   - index: The index of the element that was updated
-    func section(_ section: Section, didUpdateElementAt index: Int)
+    func section(_ section: Section, didUpdateElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that an element was updated
+    /// - Parameters:
+    ///   - section: The section where the update occurred
+    ///   - index: The index of the element that was updated
+    func section(_ section: Section, didUpdateElementsAt indexSet: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that an element was moved
     /// - Parameters:
     ///   - section: The section where the move occurred
     ///   - index: The source index of the element that was moved
     ///   - newIndex: The target index of the element that was moved
-    func section(_ section: Section, didMoveElementAt index: Int, to newIndex: Int)
+    func section(_ section: Section, didMoveElementAt index: Int, to newIndex: Int, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Returns the currently selected indexes in the specified section
     /// - Parameter section: The section to query
@@ -82,4 +103,18 @@ public protocol SectionUpdateDelegate: class {
     ///   - destinationIndex: The final index where the element will be moved to
     func section(_ section: Section, move sourceIndex: Int, to destinationIndex: Int)
 
+}
+
+extension SectionUpdateDelegate {
+    public func section(_ section: Section, didInsertElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        self.section(section, didInsertElementsAt: IndexSet(arrayLiteral: index), performUpdate: updatePerformer)
+    }
+
+    public func section(_ section: Section, didRemoveElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        self.section(section, didRemoveElementsAt: IndexSet(arrayLiteral: index), performUpdate: updatePerformer)
+    }
+
+    public func section(_ section: Section, didUpdateElementAt index: Int, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        self.section(section, didUpdateElementsAt: IndexSet(arrayLiteral: index), performUpdate: updatePerformer)
+    }
 }

--- a/Sources/Composed/Core/SectionProvider.swift
+++ b/Sources/Composed/Core/SectionProvider.swift
@@ -37,15 +37,18 @@ public protocol AggregateSectionProvider: SectionProvider {
      context of the callee
 
      - parameter provider: The provider to calculate the section offset of
-     - returns: The section offset of the provided section provider, or -1 if
+     - returns: The section offset of the provided section provider, or `nil`if
      the section provider is not in the hierachy
      */
-    func sectionOffset(for provider: SectionProvider) -> Int
+    func sectionOffset(for provider: SectionProvider) -> Int?
 
 }
 
 /// A delegate that will respond to update events from a `SectionProvider`
 public protocol SectionProviderUpdateDelegate: class {
+    /// A closure that will be called synchronously on the main thread. It must perform the updates
+    /// associated with the mapping change before returning.
+    typealias UpdatePerformer = () -> Void
 
     /// /// Notifies the delegate before a provider will process updates
     /// - Parameter provider: The provider that will be updated
@@ -57,21 +60,21 @@ public protocol SectionProviderUpdateDelegate: class {
 
     /// Notifies the delegate that all sections should be invalidated, ignoring individual updates
     /// - Parameter provider: The provider that requested the invalidation
-    func invalidateAll(_ provider: SectionProvider)
+    func invalidateAll(_ provider: SectionProvider, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that sections were inserted
     /// - Parameters:
     ///   - provider: The provider where the inserts occurred
     ///   - sections: The sections that were inserted
     ///   - indexes: The indexes of the sections that were inserted
-    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet)
+    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
 
     /// Notifies the delegate that sections were removed
     /// - Parameters:
     ///   - provider: The provider where the removes occurred
     ///   - sections: The sections that were removed
     ///   - indexes: The indexes of the sections that were removed
-    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet)
+    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
 }
 
 // Default implementations to minimise `SectionProvider` implementation requirements
@@ -85,16 +88,16 @@ public extension SectionProviderUpdateDelegate where Self: SectionProvider {
         updateDelegate?.didEndUpdating(self)
     }
 
-    func invalidateAll(_ provider: SectionProvider) {
-        updateDelegate?.invalidateAll(provider)
+    func invalidateAll(_ provider: SectionProvider, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        updateDelegate?.invalidateAll(provider, performUpdate: updatePerformer)
     }
 
-    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet) {
-        updateDelegate?.provider(provider, didInsertSections: sections, at: indexes)
+    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        updateDelegate?.provider(provider, didInsertSections: sections, at: indexes, performUpdate: updatePerformer)
     }
 
-    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet) {
-        updateDelegate?.provider(provider, didRemoveSections: sections, at: indexes)
+    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        updateDelegate?.provider(provider, didRemoveSections: sections, at: indexes, performUpdate: updatePerformer)
     }
 
 }

--- a/Sources/Composed/Core/SectionProviderMappingDelegate.swift
+++ b/Sources/Composed/Core/SectionProviderMappingDelegate.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// A delegate for responding to mapping updates. Updates will be stored and _could_ be performed
+/// in the future to allow multiple updates to occur at once. This will occur when
+/// `mappingWillBeginUpdating` is called multiple times before `mappingDidEndUpdating` is called.
+public protocol SectionProviderMappingDelegate: class {
+    /// A closure that will be called synchronously on the main thread. It must perform the updates
+    /// associated with the mapping change before returning.
+    typealias UpdatePerformer = () -> Void
+
+    /// Notifies the delegate that the mapping will being updating
+    /// - Parameter mapping: The mapping that provided this update
+    func mappingWillBeginUpdating(_ mapping: SectionProviderMapping)
+
+    /// Notifies the delegate that the mapping did end updating
+    /// - Parameter mapping: The mapping that provided this update
+    func mappingDidEndUpdating(_ mapping: SectionProviderMapping)
+
+    /// Notifies the delegate that the mapping was invalidated
+    /// - Parameter mapping: The mapping that provided this update
+    func mappingDidInvalidate(_ mapping: SectionProviderMapping, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did insert sections
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - sections: The section indexes
+    func mapping(_ mapping: SectionProviderMapping, didInsertSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did insert elements
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - indexPaths: The element indexPaths
+    func mapping(_ mapping: SectionProviderMapping, didInsertElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did remove sections
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - sections: The section indexes
+    func mapping(_ mapping: SectionProviderMapping, didRemoveSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did remove elements
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - indexPaths: The element indexPaths
+    func mapping(_ mapping: SectionProviderMapping, didRemoveElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did update sections
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - sections: The section indexes
+    func mapping(_ mapping: SectionProviderMapping, didUpdateSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did update elements
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - indexPaths: The element indexPaths
+    func mapping(_ mapping: SectionProviderMapping, didUpdateElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Notifies the delegate that the mapping did move elements
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - moves: The source and target element indexPaths as a tuple
+    func mapping(_ mapping: SectionProviderMapping, didMoveElementsAt moves: [(IndexPath, IndexPath)], performUpdate updatePerformer: @escaping UpdatePerformer)
+
+    /// Asks the delegate for its selected indexes in the specified section
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - section: The section index
+    func mapping(_ mapping: SectionProviderMapping, selectedIndexesIn section: Int) -> [Int]
+
+    /// Asks the delegate to select the specified indexPath
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - indexPath: The element indexPath
+    func mapping(_ mapping: SectionProviderMapping, select indexPath: IndexPath)
+
+    /// Asks the delegate to deselect the specified indexPath
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - indexPath: The element indexPath
+    func mapping(_ mapping: SectionProviderMapping, deselect indexPath: IndexPath)
+
+    /// Asks the delegate to move the specified indexPath
+    /// - Parameters:
+    ///   - mapping: The mapping that provided this update
+    ///   - sourceIndexPath: The initial indexPath
+    ///   - destinationIndexPath: The final indexPath
+    func mapping(_ mapping: SectionProviderMapping, move sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)
+
+}

--- a/Sources/Composed/Providers/SegmentedSectionProvider.swift
+++ b/Sources/Composed/Providers/SegmentedSectionProvider.swift
@@ -1,252 +1,252 @@
-import Foundation
-
-/**
- Represents an collection of `Section`'s and `SectionProvider`'s. The provider supports infinite nesting, including other `SegmentedSectionProvider`'s. One or zero children may be active at any time, so `numberOfSections` and `numberOfElements(in:)` will return values representative of the currenly active child only.
-
-     let provider = SegmentedSectionProvider()
-     provider.append(section1) // 5 elements
-     provider.append(section2) // 3 elements
-
-     provider.currentIndex = 1
-
-     provider.numberOfSections        // returns 1
-     provider.numberOfElements(in: 0) // return 3
-     provider.numberOfElements(in: 1) // out-of-bounds error
- */
-open class SegmentedSectionProvider: AggregateSectionProvider, SectionProviderUpdateDelegate {
-
-    public enum Child: Equatable {
-        case provider(SectionProvider)
-        case section(Section)
-
-        public static func == (lhs: Child, rhs: Child) -> Bool {
-            switch (lhs, rhs) {
-            case let (.section(lhs), .section(rhs)): return lhs === rhs
-            case let (.provider(lhs), .provider(rhs)): return lhs === rhs
-            default: return false
-            }
-        }
-    }
-
-    open weak var updateDelegate: SectionProviderUpdateDelegate?
-
-    /// Represents all of the children this provider contains
-    public private(set) var children: [Child] = []
-
-    private var _currentIndex: Int = -1
-    /// Get/set the index of the child to make 'active'
-    public var currentIndex: Int {
-        get { _currentIndex }
-        set {
-            if children.isEmpty { _currentIndex = -1 }
-
-            // grab the old index
-            let oldIndex = _currentIndex
-            // clamp the value
-            let newIndex = max(0, min(children.count - 1, newValue))
-
-            // if the value won't result in a change, ignore it
-            if _currentIndex == newIndex { return }
-
-            updateDelegate?.willBeginUpdating(self)
-            _currentIndex = newIndex
-            updateDelegate(forRemovalOf: children[oldIndex])
-            updateDelegate(forInsertionOf: children[newIndex])
-            updateDelegate?.didEndUpdating(self)
-        }
-    }
-
-    /// Returns the currently 'active' child
-    private var currentChild: Child? {
-        guard children.indices.contains(_currentIndex) else { return nil }
-        return children[_currentIndex]
-    }
-
-    /// Returns all the providers this provider contains
-    public var providers: [SectionProvider] {
-        switch currentChild {
-        case .section:
-            return []
-        case let .provider(childProvider):
-            return [childProvider]
-        case .none:
-            return []
-        }
-    }
-
-    /// Returns all the sections this provider contains
-    public var sections: [Section] {
-        switch currentChild {
-        case let .provider(childProvider):
-            return childProvider.sections
-        case let .section(section):
-            return [section]
-        case .none:
-            return []
-        }
-    }
-
-    public init() { }
-
-    public var numberOfSections: Int {
-        switch currentChild {
-        case let .provider(childProvider):
-            return childProvider.numberOfSections
-        case .section:
-            return 1
-        case .none:
-            return 0
-        }
-    }
-
-    /// Returns the number of elements in the specified section
-    /// - Parameter section: The section index
-    /// - Returns: The number of elements
-    public func numberOfElements(in section: Int) -> Int {
-        return sections[section].numberOfElements
-    }
-
-    public func sectionOffset(for provider: SectionProvider) -> Int {
-        guard provider !== self else { return 0 }
-
-        var offset: Int = 0
-
-        switch currentChild {
-        case .section:
-            offset += 1
-        case .provider(let childProvider):
-            if childProvider === provider {
-                return offset
-            } else if let childProvider = childProvider as? AggregateSectionProvider {
-                let sectionOffset = childProvider.sectionOffset(for: provider)
-                if sectionOffset != -1 {
-                    return offset + sectionOffset
-                }
-            }
-
-            offset += childProvider.numberOfSections
-        case .none:
-            break
-        }
-
-        return -1
-    }
-
-    /// Appends the specified `SectionProvider` to the provider
-    /// - Parameter child: The `SectionProvider` to append
-    public func append(_ child: SectionProvider) {
-        insert(child, at: children.count)
-    }
-
-    /// Appends the specified `Section` to the provider
-    /// - Parameter child: The `Section` to append
-    public func append(_ child: Section) {
-        insert(child, at: children.count)
-    }
-
-    /// Inserts the specified `SectionProvider` at the given index
-    /// - Parameters:
-    ///   - child: The `SectionProvider` to insert
-    ///   - index: The index where the `SectionProvider` should be inserted
-    public func insert(_ child: SectionProvider, at index: Int) {
-        guard (children.startIndex...children.endIndex).contains(index) else { fatalError("Index out of bounds: \(index)") }
-        children.insert(.provider(child), at: index)
-        insert(at: index)
-    }
-
-    /// Inserts the specified `Section` at the given index
-    /// - Parameters:
-    ///   - child: The `Section` to insert
-    ///   - index: The index where the `Section` should be inserted
-    public func insert(_ child: Section, at index: Int) {
-        guard (children.startIndex...children.endIndex).contains(index) else { fatalError("Index out of bounds: \(index)") }
-        children.insert(.section(child), at: index)
-        insert(at: index)
-    }
-
-    private func insert(at index: Int) {
-        if children.count == 1 {
-            _currentIndex = index
-            updateDelegate(forInsertionOf: currentChild)
-        } else if index <= _currentIndex {
-            // Just keep the index in sync
-            _currentIndex += 1
-        } else {
-            // we're inserting at the end, do nothing
-        }
-    }
-
-    /// Removes the specified `Section`
-    /// - Parameter child: The `Section` to remove
-    public func remove(_ child: Section) {
-        remove(.section(child))
-    }
-
-    /// Removes the specified `SectionProvider`
-    /// - Parameter child: The `SectionProvider` to remove
-    public func remove(_ child: SectionProvider) {
-        remove(.provider(child))
-    }
-
-    private func remove(_ child: Child) {
-        guard let index = children.firstIndex(of: child) else { return }
-        remove(at: index)
-    }
-
-    /// Remove the child at the specified index
-    /// - Parameter index: The index to remove
-    public func remove(at index: Int) {
-        guard children.indices.contains(index) else { return }
-
-        let child = currentChild
-        children.remove(at: index)
-
-        // if this is the last section
-        if children.isEmpty {
-            _currentIndex = -1
-            updateDelegate(forRemovalOf: child)
-        }
-        // if our index is still technically valid
-        else if _currentIndex <= children.count - 1 {
-            updateDelegate?.willBeginUpdating(self)
-            updateDelegate(forRemovalOf: child)
-            updateDelegate(forInsertionOf: currentChild)
-            updateDelegate?.didEndUpdating(self)
-        }
-        // if our index should be decremented
-        else {
-            updateDelegate?.willBeginUpdating(self)
-            _currentIndex -= 1
-            updateDelegate(forRemovalOf: child)
-            updateDelegate(forInsertionOf: currentChild)
-            updateDelegate?.didEndUpdating(self)
-        }
-    }
-
-    // MARK: UpdateDelegate
-
-    private func updateDelegate(forRemovalOf child: Child?) {
-        switch child {
-        case let .provider(provider):
-            provider.updateDelegate = nil
-            updateDelegate?.provider(self, didRemoveSections: provider.sections, at: IndexSet(provider.sections.indices))
-        case let .section(section):
-            updateDelegate?.provider(self, didRemoveSections: [section], at: IndexSet(integer: 0))
-        case .none:
-            break
-        }
-    }
-
-    private func updateDelegate(forInsertionOf child: Child?) {
-        switch child {
-        case let .provider(provider):
-            provider.updateDelegate = self
-            updateDelegate?.provider(self, didInsertSections: provider.sections, at: IndexSet(provider.sections.indices))
-        case let .section(section):
-            updateDelegate?.provider(self, didInsertSections: [section], at: IndexSet(integer: 0))
-        case .none:
-            break
-        }
-    }
-
-}
+//import Foundation
+//
+///**
+// Represents an collection of `Section`'s and `SectionProvider`'s. The provider supports infinite nesting, including other `SegmentedSectionProvider`'s. One or zero children may be active at any time, so `numberOfSections` and `numberOfElements(in:)` will return values representative of the currenly active child only.
+//
+//     let provider = SegmentedSectionProvider()
+//     provider.append(section1) // 5 elements
+//     provider.append(section2) // 3 elements
+//
+//     provider.currentIndex = 1
+//
+//     provider.numberOfSections        // returns 1
+//     provider.numberOfElements(in: 0) // return 3
+//     provider.numberOfElements(in: 1) // out-of-bounds error
+// */
+//open class SegmentedSectionProvider: AggregateSectionProvider, SectionProviderUpdateDelegate {
+//
+//    public enum Child: Equatable {
+//        case provider(SectionProvider)
+//        case section(Section)
+//
+//        public static func == (lhs: Child, rhs: Child) -> Bool {
+//            switch (lhs, rhs) {
+//            case let (.section(lhs), .section(rhs)): return lhs === rhs
+//            case let (.provider(lhs), .provider(rhs)): return lhs === rhs
+//            default: return false
+//            }
+//        }
+//    }
+//
+//    open weak var updateDelegate: SectionProviderUpdateDelegate?
+//
+//    /// Represents all of the children this provider contains
+//    public private(set) var children: [Child] = []
+//
+//    private var _currentIndex: Int = -1
+//    /// Get/set the index of the child to make 'active'
+//    public var currentIndex: Int {
+//        get { _currentIndex }
+//        set {
+//            if children.isEmpty { _currentIndex = -1 }
+//
+//            // grab the old index
+//            let oldIndex = _currentIndex
+//            // clamp the value
+//            let newIndex = max(0, min(children.count - 1, newValue))
+//
+//            // if the value won't result in a change, ignore it
+//            if _currentIndex == newIndex { return }
+//
+//            updateDelegate?.willBeginUpdating(self)
+//            _currentIndex = newIndex
+//            updateDelegate(forRemovalOf: children[oldIndex])
+//            updateDelegate(forInsertionOf: children[newIndex])
+//            updateDelegate?.didEndUpdating(self)
+//        }
+//    }
+//
+//    /// Returns the currently 'active' child
+//    private var currentChild: Child? {
+//        guard children.indices.contains(_currentIndex) else { return nil }
+//        return children[_currentIndex]
+//    }
+//
+//    /// Returns all the providers this provider contains
+//    public var providers: [SectionProvider] {
+//        switch currentChild {
+//        case .section:
+//            return []
+//        case let .provider(childProvider):
+//            return [childProvider]
+//        case .none:
+//            return []
+//        }
+//    }
+//
+//    /// Returns all the sections this provider contains
+//    public var sections: [Section] {
+//        switch currentChild {
+//        case let .provider(childProvider):
+//            return childProvider.sections
+//        case let .section(section):
+//            return [section]
+//        case .none:
+//            return []
+//        }
+//    }
+//
+//    public init() { }
+//
+//    public var numberOfSections: Int {
+//        switch currentChild {
+//        case let .provider(childProvider):
+//            return childProvider.numberOfSections
+//        case .section:
+//            return 1
+//        case .none:
+//            return 0
+//        }
+//    }
+//
+//    /// Returns the number of elements in the specified section
+//    /// - Parameter section: The section index
+//    /// - Returns: The number of elements
+//    public func numberOfElements(in section: Int) -> Int {
+//        return sections[section].numberOfElements
+//    }
+//
+//    public func sectionOffset(for provider: SectionProvider) -> Int {
+//        guard provider !== self else { return 0 }
+//
+//        var offset: Int = 0
+//
+//        switch currentChild {
+//        case .section:
+//            offset += 1
+//        case .provider(let childProvider):
+//            if childProvider === provider {
+//                return offset
+//            } else if let childProvider = childProvider as? AggregateSectionProvider {
+//                let sectionOffset = childProvider.sectionOffset(for: provider)
+//                if sectionOffset != -1 {
+//                    return offset + sectionOffset
+//                }
+//            }
+//
+//            offset += childProvider.numberOfSections
+//        case .none:
+//            break
+//        }
+//
+//        return -1
+//    }
+//
+//    /// Appends the specified `SectionProvider` to the provider
+//    /// - Parameter child: The `SectionProvider` to append
+//    public func append(_ child: SectionProvider) {
+//        insert(child, at: children.count)
+//    }
+//
+//    /// Appends the specified `Section` to the provider
+//    /// - Parameter child: The `Section` to append
+//    public func append(_ child: Section) {
+//        insert(child, at: children.count)
+//    }
+//
+//    /// Inserts the specified `SectionProvider` at the given index
+//    /// - Parameters:
+//    ///   - child: The `SectionProvider` to insert
+//    ///   - index: The index where the `SectionProvider` should be inserted
+//    public func insert(_ child: SectionProvider, at index: Int) {
+//        guard (children.startIndex...children.endIndex).contains(index) else { fatalError("Index out of bounds: \(index)") }
+//        children.insert(.provider(child), at: index)
+//        insert(at: index)
+//    }
+//
+//    /// Inserts the specified `Section` at the given index
+//    /// - Parameters:
+//    ///   - child: The `Section` to insert
+//    ///   - index: The index where the `Section` should be inserted
+//    public func insert(_ child: Section, at index: Int) {
+//        guard (children.startIndex...children.endIndex).contains(index) else { fatalError("Index out of bounds: \(index)") }
+//        children.insert(.section(child), at: index)
+//        insert(at: index)
+//    }
+//
+//    private func insert(at index: Int) {
+//        if children.count == 1 {
+//            _currentIndex = index
+//            updateDelegate(forInsertionOf: currentChild)
+//        } else if index <= _currentIndex {
+//            // Just keep the index in sync
+//            _currentIndex += 1
+//        } else {
+//            // we're inserting at the end, do nothing
+//        }
+//    }
+//
+//    /// Removes the specified `Section`
+//    /// - Parameter child: The `Section` to remove
+//    public func remove(_ child: Section) {
+//        remove(.section(child))
+//    }
+//
+//    /// Removes the specified `SectionProvider`
+//    /// - Parameter child: The `SectionProvider` to remove
+//    public func remove(_ child: SectionProvider) {
+//        remove(.provider(child))
+//    }
+//
+//    private func remove(_ child: Child) {
+//        guard let index = children.firstIndex(of: child) else { return }
+//        remove(at: index)
+//    }
+//
+//    /// Remove the child at the specified index
+//    /// - Parameter index: The index to remove
+//    public func remove(at index: Int) {
+//        guard children.indices.contains(index) else { return }
+//
+//        let child = currentChild
+//        children.remove(at: index)
+//
+//        // if this is the last section
+//        if children.isEmpty {
+//            _currentIndex = -1
+//            updateDelegate(forRemovalOf: child)
+//        }
+//        // if our index is still technically valid
+//        else if _currentIndex <= children.count - 1 {
+//            updateDelegate?.willBeginUpdating(self)
+//            updateDelegate(forRemovalOf: child)
+//            updateDelegate(forInsertionOf: currentChild)
+//            updateDelegate?.didEndUpdating(self)
+//        }
+//        // if our index should be decremented
+//        else {
+//            updateDelegate?.willBeginUpdating(self)
+//            _currentIndex -= 1
+//            updateDelegate(forRemovalOf: child)
+//            updateDelegate(forInsertionOf: currentChild)
+//            updateDelegate?.didEndUpdating(self)
+//        }
+//    }
+//
+//    // MARK: UpdateDelegate
+//
+//    private func updateDelegate(forRemovalOf child: Child?) {
+//        switch child {
+//        case let .provider(provider):
+//            provider.updateDelegate = nil
+//            updateDelegate?.provider(self, didRemoveSections: provider.sections, at: IndexSet(provider.sections.indices))
+//        case let .section(section):
+//            updateDelegate?.provider(self, didRemoveSections: [section], at: IndexSet(integer: 0))
+//        case .none:
+//            break
+//        }
+//    }
+//
+//    private func updateDelegate(forInsertionOf child: Child?) {
+//        switch child {
+//        case let .provider(provider):
+//            provider.updateDelegate = self
+//            updateDelegate?.provider(self, didInsertSections: provider.sections, at: IndexSet(provider.sections.indices))
+//        case let .section(section):
+//            updateDelegate?.provider(self, didInsertSections: [section], at: IndexSet(integer: 0))
+//        case .none:
+//            break
+//        }
+//    }
+//
+//}

--- a/Sources/Composed/Sections/ManagedSection.swift
+++ b/Sources/Composed/Sections/ManagedSection.swift
@@ -1,151 +1,151 @@
-import CoreData
-
-/**
- Represents a section that provides its elements via an `NSFetchedResultsController`. This section is useful for representing data managed by CoreData.
-
- This type conforms to various standard library protocols to provide a more familiar API.
-
- `ManagedSection` conforms to the following protocols from the standard library:
-
-     Sequence
-     RandomAccessCollection
-     BidirectionalCollection
-
- Example usage:
-
-     let section = ManagedSection<Person>(managedObjectContext: context)
-     let request: NSFetchRequest<Person> = Person.fetchRequest()
-     request.sortDescriptors = [...]
-     section.replace(fetchRequest: request)
- */
-open class ManagedSection<Element>: NSObject, NSFetchedResultsControllerDelegate, Section where Element: NSManagedObject {
-
-    /// Returns the `NSManagedObjectContext` associated with this section
-    public let managedObjectContext: NSManagedObjectContext
-
-    public weak var updateDelegate: SectionUpdateDelegate?
-
-    // The current controller that will return elements
-    private var fetchedResultsController: NSFetchedResultsController<Element>?
-
-    // A convenience property for return all fetched elements
-    public var elements: [Element] {
-        return fetchedResultsController?.fetchedObjects ?? []
-    }
-
-    public var numberOfElements: Int {
-        return fetchedResultsController?.fetchedObjects?.count ?? 0
-    }
-
-    /// Makes a `ManagedSection` with the specified context and optional request
-    /// - Parameters:
-    ///   - managedObjectContext: The context to associate with this section
-    ///   - fetchRequest: The initial request to use for fetching data (optional)
-    public init(managedObjectContext: NSManagedObjectContext, fetchRequest: NSFetchRequest<Element>? = nil) {
-        self.managedObjectContext = managedObjectContext
-        super.init()
-
-        if let fetchRequest = fetchRequest {
-            replace(fetchRequest: fetchRequest)
-        }
-    }
-
-    /// Replaces the current fetch request with the specified request
-    /// - Parameter fetchRequest: The new fetch request
-    public func replace(fetchRequest: NSFetchRequest<Element>, cacheName: String? = nil) {
-        fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: managedObjectContext, sectionNameKeyPath: nil, cacheName: cacheName)
-        fetchedResultsController?.delegate = self
-
-        do {
-            try fetchedResultsController?.performFetch()
-            updateDelegate?.invalidateAll(self)
-        } catch {
-            assertionFailure(error.localizedDescription)
-        }
-    }
-
-    /// Returns the element at the specified index
-    /// - Parameter index: The position of the element to access. `index` must be greater than or equal to `startIndex` and less than `endIndex`.
-    /// - Returns: If the index is valid, the element. Otherwise
-    public func element(at index: Int) -> Element {
-        guard let controller = fetchedResultsController else {
-            fatalError("A valid fetchRequest has not been configured. You must provide a fetchRequest before calling this method.")
-        }
-
-        return controller.object(at: IndexPath(item: index, section: 0))
-    }
-
-    /// The index of the specified element. Returns nil if the element is _not_ in this section.
-    /// - Parameter element: The element to look lookup
-    /// - Returns: The index of the element if it is in this section, nil otherwise
-    public func index(of element: Element) -> Int? {
-        return fetchedResultsController?.indexPath(forObject: element)?.item
-    }
-
-    public private(set) var isSuspended: Bool = false
-
-    public func suspend() {
-        isSuspended = true
-    }
-
-    public func resume() {
-        isSuspended = false
-    }
-
-    public func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        guard !isSuspended else { return }
-        updateDelegate?.willBeginUpdating(self)
-    }
-
-    public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-        guard !isSuspended else { return }
-
-        switch type {
-        case .insert:
-            updateDelegate?.section(self, didInsertElementAt: newIndexPath!.item)
-        case .delete:
-            let sections = fetchedResultsController?.sections ?? []
-            if !sections.isEmpty, sections.first?.numberOfObjects == 0 {
-                updateDelegate?.invalidateAll(self)
-            } else {
-                updateDelegate?.section(self, didRemoveElementAt: indexPath!.item)
-            }
-        case .update:
-            updateDelegate?.section(self, didUpdateElementAt: indexPath!.item)
-        case .move:
-            updateDelegate?.section(self, didMoveElementAt: indexPath!.item, to: newIndexPath!.item)
-        default:
-            fatalError("Unsupported type")
-        }
-    }
-
-    public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        guard !isSuspended else { return }
-        updateDelegate?.didEndUpdating(self)
-    }
-
-}
-
-extension ManagedSection: RandomAccessCollection, BidirectionalCollection {
-
-    public typealias Index = Array<Element>.Index
-
-    public var isEmpty: Bool { return elements.isEmpty }
-    public var startIndex: Index { return elements.startIndex }
-    public var endIndex: Index { return elements.endIndex }
-
-    public subscript(position: Index) -> Element {
-        return elements[position]
-    }
-
-}
-
-extension ManagedSection: Sequence {
-
-    public typealias Iterator = Array<Element>.Iterator
-
-    public func makeIterator() -> IndexingIterator<Array<Element>> {
-        return elements.makeIterator()
-    }
-
-}
+//import CoreData
+//
+///**
+// Represents a section that provides its elements via an `NSFetchedResultsController`. This section is useful for representing data managed by CoreData.
+//
+// This type conforms to various standard library protocols to provide a more familiar API.
+//
+// `ManagedSection` conforms to the following protocols from the standard library:
+//
+//     Sequence
+//     RandomAccessCollection
+//     BidirectionalCollection
+//
+// Example usage:
+//
+//     let section = ManagedSection<Person>(managedObjectContext: context)
+//     let request: NSFetchRequest<Person> = Person.fetchRequest()
+//     request.sortDescriptors = [...]
+//     section.replace(fetchRequest: request)
+// */
+//open class ManagedSection<Element>: NSObject, NSFetchedResultsControllerDelegate, Section where Element: NSManagedObject {
+//
+//    /// Returns the `NSManagedObjectContext` associated with this section
+//    public let managedObjectContext: NSManagedObjectContext
+//
+//    public weak var updateDelegate: SectionUpdateDelegate?
+//
+//    // The current controller that will return elements
+//    private var fetchedResultsController: NSFetchedResultsController<Element>?
+//
+//    // A convenience property for return all fetched elements
+//    public var elements: [Element] {
+//        return fetchedResultsController?.fetchedObjects ?? []
+//    }
+//
+//    public var numberOfElements: Int {
+//        return fetchedResultsController?.fetchedObjects?.count ?? 0
+//    }
+//
+//    /// Makes a `ManagedSection` with the specified context and optional request
+//    /// - Parameters:
+//    ///   - managedObjectContext: The context to associate with this section
+//    ///   - fetchRequest: The initial request to use for fetching data (optional)
+//    public init(managedObjectContext: NSManagedObjectContext, fetchRequest: NSFetchRequest<Element>? = nil) {
+//        self.managedObjectContext = managedObjectContext
+//        super.init()
+//
+//        if let fetchRequest = fetchRequest {
+//            replace(fetchRequest: fetchRequest)
+//        }
+//    }
+//
+//    /// Replaces the current fetch request with the specified request
+//    /// - Parameter fetchRequest: The new fetch request
+//    public func replace(fetchRequest: NSFetchRequest<Element>, cacheName: String? = nil) {
+//        fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: managedObjectContext, sectionNameKeyPath: nil, cacheName: cacheName)
+//        fetchedResultsController?.delegate = self
+//
+//        do {
+//            try fetchedResultsController?.performFetch()
+//            updateDelegate?.invalidateAll(self)
+//        } catch {
+//            assertionFailure(error.localizedDescription)
+//        }
+//    }
+//
+//    /// Returns the element at the specified index
+//    /// - Parameter index: The position of the element to access. `index` must be greater than or equal to `startIndex` and less than `endIndex`.
+//    /// - Returns: If the index is valid, the element. Otherwise
+//    public func element(at index: Int) -> Element {
+//        guard let controller = fetchedResultsController else {
+//            fatalError("A valid fetchRequest has not been configured. You must provide a fetchRequest before calling this method.")
+//        }
+//
+//        return controller.object(at: IndexPath(item: index, section: 0))
+//    }
+//
+//    /// The index of the specified element. Returns nil if the element is _not_ in this section.
+//    /// - Parameter element: The element to look lookup
+//    /// - Returns: The index of the element if it is in this section, nil otherwise
+//    public func index(of element: Element) -> Int? {
+//        return fetchedResultsController?.indexPath(forObject: element)?.item
+//    }
+//
+//    public private(set) var isSuspended: Bool = false
+//
+//    public func suspend() {
+//        isSuspended = true
+//    }
+//
+//    public func resume() {
+//        isSuspended = false
+//    }
+//
+//    public func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+//        guard !isSuspended else { return }
+//        updateDelegate?.willBeginUpdating(self)
+//    }
+//
+//    public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+//        guard !isSuspended else { return }
+//
+//        switch type {
+//        case .insert:
+//            updateDelegate?.section(self, didInsertElementAt: newIndexPath!.item)
+//        case .delete:
+//            let sections = fetchedResultsController?.sections ?? []
+//            if !sections.isEmpty, sections.first?.numberOfObjects == 0 {
+//                updateDelegate?.invalidateAll(self)
+//            } else {
+//                updateDelegate?.section(self, didRemoveElementAt: indexPath!.item)
+//            }
+//        case .update:
+//            updateDelegate?.section(self, didUpdateElementAt: indexPath!.item)
+//        case .move:
+//            updateDelegate?.section(self, didMoveElementAt: indexPath!.item, to: newIndexPath!.item)
+//        default:
+//            fatalError("Unsupported type")
+//        }
+//    }
+//
+//    public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+//        guard !isSuspended else { return }
+//        updateDelegate?.didEndUpdating(self)
+//    }
+//
+//}
+//
+//extension ManagedSection: RandomAccessCollection, BidirectionalCollection {
+//
+//    public typealias Index = Array<Element>.Index
+//
+//    public var isEmpty: Bool { return elements.isEmpty }
+//    public var startIndex: Index { return elements.startIndex }
+//    public var endIndex: Index { return elements.endIndex }
+//
+//    public subscript(position: Index) -> Element {
+//        return elements[position]
+//    }
+//
+//}
+//
+//extension ManagedSection: Sequence {
+//
+//    public typealias Iterator = Array<Element>.Iterator
+//
+//    public func makeIterator() -> IndexingIterator<Array<Element>> {
+//        return elements.makeIterator()
+//    }
+//
+//}

--- a/Sources/Composed/Sections/SingleElementSection.swift
+++ b/Sources/Composed/Sections/SingleElementSection.swift
@@ -35,21 +35,24 @@ open class SingleElementSection<Element>: Section {
     /// Replaces the element with the specified element
     /// - Parameter element: The new element
     public func replace(element: Element) {
-        updateDelegate?.willBeginUpdating(self)
         let wasEmpty = isEmpty
-        self.element = element
 
         switch (wasEmpty, isEmpty) {
         case (true, true):
             break
         case (true, false):
-            updateDelegate?.section(self, didInsertElementAt: 0)
+            updateDelegate?.section(self, didInsertElementAt: 0) { [weak self] in
+                self?.element = element
+            }
         case (false, true):
-            updateDelegate?.section(self, didRemoveElementAt: 0)
+            updateDelegate?.section(self, didRemoveElementAt: 0) { [weak self] in
+                self?.element = element
+            }
         case (false, false):
-            updateDelegate?.section(self, didUpdateElementAt: 0)
+            updateDelegate?.section(self, didUpdateElementAt: 0) { [weak self] in
+                self?.element = element
+            }
         }
-        updateDelegate?.didEndUpdating(self)
     }
 
 }

--- a/Tests/ComposedTests/ComposedSectionProvider.swift
+++ b/Tests/ComposedTests/ComposedSectionProvider.swift
@@ -125,9 +125,9 @@ final class ComposedSectionProvider_Spec: QuickSpec {
 private final class MockSectionProviderUpdateDelegate: SectionProviderUpdateDelegate {
     private(set) var willBeginUpdatingCalls: [SectionProvider] = []
     private(set) var didEndUpdatingCalls: [SectionProvider] = []
-    private(set) var invalidateAllCalls: [SectionProvider] = []
-    private(set) var didInsertSectionsCalls: [(SectionProvider, [Section], IndexSet)] = []
-    private(set) var didRemoveSectionsCalls: [(SectionProvider, [Section], IndexSet)] = []
+    private(set) var invalidateAllCalls: [(SectionProvider, UpdatePerformer)] = []
+    private(set) var didInsertSectionsCalls: [(SectionProvider, [Section], IndexSet, UpdatePerformer)] = []
+    private(set) var didRemoveSectionsCalls: [(SectionProvider, [Section], IndexSet, UpdatePerformer)] = []
 
     func willBeginUpdating(_ provider: SectionProvider) {
         willBeginUpdatingCalls.append(provider)
@@ -137,15 +137,15 @@ private final class MockSectionProviderUpdateDelegate: SectionProviderUpdateDele
         didEndUpdatingCalls.append(provider)
     }
 
-    func invalidateAll(_ provider: SectionProvider) {
-        invalidateAllCalls.append(provider)
+    func invalidateAll(_ provider: SectionProvider, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        invalidateAllCalls.append((provider, updatePerformer))
     }
 
-    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet) {
-        didInsertSectionsCalls.append((provider, sections, indexes))
+    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        didInsertSectionsCalls.append((provider, sections, indexes, updatePerformer))
     }
 
-    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet) {
-        didRemoveSectionsCalls.append((provider, sections, indexes))
+    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        didRemoveSectionsCalls.append((provider, sections, indexes, updatePerformer))
     }
 }

--- a/Tests/ComposedTests/SectionProviderDelegate+Spec.swift
+++ b/Tests/ComposedTests/SectionProviderDelegate+Spec.swift
@@ -39,9 +39,22 @@ final class SectionProviderDelegate_Spec: QuickSpec {
         }
 
         it("section should equal 1") {
-            expect(delegate.didInsertSections?.indexes) === IndexSet(integer: 0)
+            expect(delegate.didInsertSections?.indexes) == IndexSet(integer: 0)
         }
 
+        it("should have zero sections before the update closure has been called") {
+            expect(global.numberOfSections) == 0
+        }
+
+        context("when update closure has been called") {
+            beforeEach {
+                delegate?.didInsertSections?.updatePerformer()
+            }
+
+            it("should have new sections") {
+                expect(global.numberOfSections) == 1
+            }
+        }
     }
 
 }
@@ -55,7 +68,7 @@ final class MockDelegate: SectionProviderUpdateDelegate {
         
     }
 
-    func invalidateAll(_ provider: SectionProvider) {
+    func invalidateAll(_ provider: SectionProvider, performUpdate updatePerformer: @escaping UpdatePerformer) {
 
     }
 
@@ -67,15 +80,14 @@ final class MockDelegate: SectionProviderUpdateDelegate {
         
     }
 
-    var didInsertSections: (provider: SectionProvider, sections: [Section], indexes: IndexSet)?
-    var didRemoveSections: (provider: SectionProvider, sections: [Section], indexes: IndexSet)?
+    var didInsertSections: (provider: SectionProvider, sections: [Section], indexes: IndexSet, updatePerformer: UpdatePerformer)?
+    var didRemoveSections: (provider: SectionProvider, sections: [Section], indexes: IndexSet, updatePerformer: UpdatePerformer)?
 
-    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet) {
-        didInsertSections = (provider, sections, indexes)
+    func provider(_ provider: SectionProvider, didInsertSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        didInsertSections = (provider, sections, indexes, updatePerformer)
     }
 
-    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet) {
-        didRemoveSections = (provider, sections, indexes)
+    func provider(_ provider: SectionProvider, didRemoveSections sections: [Section], at indexes: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
+        didRemoveSections = (provider, sections, indexes, updatePerformer)
     }
-
 }

--- a/Tests/ComposedTests/SectionProviderMapper+Spec.swift
+++ b/Tests/ComposedTests/SectionProviderMapper+Spec.swift
@@ -56,9 +56,9 @@ final class SectionProviderMapping_Spec: QuickSpec {
                         global.append(level1EmbeddedSectionProvider)
                     }
                     
-                    it("should return 2 sections") {
-                        expect(mapper.numberOfSections) == 2
-                    }
+//                    it("should return 2 sections") {
+//                        expect(mapper.numberOfSections) == 2
+//                    }
                     
                     context("and a composed section provider with 3 sections") {
                         var level2EmbeddedSectionProvider: ComposedSectionProvider!
@@ -78,17 +78,17 @@ final class SectionProviderMapping_Spec: QuickSpec {
                             level1EmbeddedSectionProvider.append(level2EmbeddedSectionProvider)
                         }
                         
-                        it("should return 5 sections") {
-                            expect(mapper.numberOfSections) == 5
-                        }
+//                        it("should return 5 sections") {
+//                            expect(mapper.numberOfSections) == 5
+//                        }
                         
-                        it("should return a section offset of 2 for the composed section provider") {
-                            expect(mapper.sectionOffset(of: level2EmbeddedSectionProvider)) == 2
-                        }
-                        
-                        it("should notify the delegate of the inserted sections") {
-                            expect(delegate.didInsertSections!.sections) == IndexSet(2...4)
-                        }
+//                        it("should return a section offset of 2 for the composed section provider") {
+//                            expect(mapper.sectionOffset(of: level2EmbeddedSectionProvider)) == 2
+//                        }
+//                        
+//                        it("should notify the delegate of the inserted sections") {
+//                            expect(delegate.didInsertSections!.sections) == IndexSet(2...4)
+//                        }
                     }
                 }
                 
@@ -109,9 +109,7 @@ final class SectionProviderMapping_Spec: QuickSpec {
     
 }
 
-final class MockSectionProviderMappingDelegate: SectionProviderMappingDelegate {
-
-    var didInsertSections: (mapping: SectionProviderMapping, sections: IndexSet)?
+final class MockSectionProviderMappingDelegate: SectionProviderMappingDelegate {    var didInsertSections: (mapping: SectionProviderMapping, sections: IndexSet)?
     var didInsertElements: (section: SectionProviderMapping, indexPaths: [IndexPath])?
 
     var didRemoveSections: (mapping: SectionProviderMapping, sections: IndexSet)?
@@ -130,29 +128,29 @@ final class MockSectionProviderMappingDelegate: SectionProviderMappingDelegate {
         didUpdate = mapping
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didInsertSections sections: IndexSet) {
+    func mapping(_ mapping: SectionProviderMapping, didInsertSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
         didInsertSections = (mapping, sections)
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didInsertElementsAt indexPaths: [IndexPath]) {
+    func mapping(_ mapping: SectionProviderMapping, didInsertElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer) {
         didInsertElements = (mapping, indexPaths)
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didRemoveSections sections: IndexSet) {
+    func mapping(_ mapping: SectionProviderMapping, didRemoveSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) {
         didRemoveSections = (mapping, sections)
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didRemoveElementsAt indexPaths: [IndexPath]) {
+    func mapping(_ mapping: SectionProviderMapping, didRemoveElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer) {
         didRemoveElements = (mapping, indexPaths)
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didUpdateSections sections: IndexSet) { }
+    func mapping(_ mapping: SectionProviderMapping, didUpdateSections sections: IndexSet, performUpdate updatePerformer: @escaping UpdatePerformer) { }
 
-    func mapping(_ mapping: SectionProviderMapping, didUpdateElementsAt indexPaths: [IndexPath]) {
+    func mapping(_ mapping: SectionProviderMapping, didUpdateElementsAt indexPaths: [IndexPath], performUpdate updatePerformer: @escaping UpdatePerformer) {
         didUpdateElements = (mapping, indexPaths)
     }
 
-    func mapping(_ mapping: SectionProviderMapping, didMoveElementsAt moves: [(IndexPath, IndexPath)]) {
+    func mapping(_ mapping: SectionProviderMapping, didMoveElementsAt moves: [(IndexPath, IndexPath)], performUpdate updatePerformer: @escaping UpdatePerformer) {
         didMoveElements = (mapping, moves)
     }
 
@@ -164,7 +162,7 @@ final class MockSectionProviderMappingDelegate: SectionProviderMappingDelegate {
     func mapping(_ mapping: SectionProviderMapping, deselect indexPath: IndexPath) { }
 
     func mappingDidEndUpdating(_ mapping: SectionProviderMapping) {}
-    func mappingDidInvalidate(_ mapping: SectionProviderMapping) {}
+    func mappingDidInvalidate(_ mapping: SectionProviderMapping, performUpdate updatePerformer: @escaping UpdatePerformer) {}
     func mapping(_ mapping: SectionProviderMapping, move sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {}
 
 }

--- a/Tests/ComposedTests/SegmentedSectionProvider.swift
+++ b/Tests/ComposedTests/SegmentedSectionProvider.swift
@@ -1,69 +1,69 @@
-import Quick
-import Nimble
-import UIKit
-
-@testable import Composed
-
-final class SegmentedSectionProvider_Spec: QuickSpec {
-
-    override func spec() {
-        var segment: SegmentedSectionProvider!
-        var child1: ComposedSectionProvider!
-        var child2: ArraySection<String>!
-        var mapping: SectionProviderMapping!
-
-        describe("SegmentedSectionProvider") {
-            beforeEach {
-                segment = SegmentedSectionProvider()
-                mapping = SectionProviderMapping(provider: segment)
-
-                child1 = ComposedSectionProvider()
-                let child1a = ArraySection<String>()
-                let child1b = ArraySection<String>()
-                child2 = ArraySection<String>()
-
-                segment.append(child1)
-                segment.append(child2)
-
-                child1.append(child1a)
-                child1.append(child1b)
-
-                print(segment.children)
-            }
-
-            context("after changing the `currentIndex") {
-                beforeEach {
-                    segment.currentIndex = 1
-                }
-
-                it("should contain 1 section") {
-                    expect(segment.numberOfSections).to(equal(1))
-                }
-
-                it("should unset the delegate of the previous child") {
-                    expect(child1.updateDelegate).to(beNil())
-                }
-
-                it("should set the delegate of the current child") {
-                    expect(child2.updateDelegate).toNot(beNil())
-                }
-            }
-
-            context("without changing the `currentIndex`") {
-                it("should contain 2 section") {
-                    expect(segment.numberOfSections).to(equal(2))
-                }
-
-                it("should set the delegate") {
-                    expect(child1.updateDelegate).toNot(beNil())
-                }
-
-                it("should not set the delegate of children") {
-                    expect(child2.updateDelegate).to(beNil())
-                }
-
-            }
-        }
-    }
-
-}
+//import Quick
+//import Nimble
+//import UIKit
+//
+//@testable import Composed
+//
+//final class SegmentedSectionProvider_Spec: QuickSpec {
+//
+//    override func spec() {
+//        var segment: SegmentedSectionProvider!
+//        var child1: ComposedSectionProvider!
+//        var child2: ArraySection<String>!
+//        var mapping: SectionProviderMapping!
+//
+//        describe("SegmentedSectionProvider") {
+//            beforeEach {
+//                segment = SegmentedSectionProvider()
+//                mapping = SectionProviderMapping(provider: segment)
+//
+//                child1 = ComposedSectionProvider()
+//                let child1a = ArraySection<String>()
+//                let child1b = ArraySection<String>()
+//                child2 = ArraySection<String>()
+//
+//                segment.append(child1)
+//                segment.append(child2)
+//
+//                child1.append(child1a)
+//                child1.append(child1b)
+//
+//                print(segment.children)
+//            }
+//
+//            context("after changing the `currentIndex") {
+//                beforeEach {
+//                    segment.currentIndex = 1
+//                }
+//
+//                it("should contain 1 section") {
+//                    expect(segment.numberOfSections).to(equal(1))
+//                }
+//
+//                it("should unset the delegate of the previous child") {
+//                    expect(child1.updateDelegate).to(beNil())
+//                }
+//
+//                it("should set the delegate of the current child") {
+//                    expect(child2.updateDelegate).toNot(beNil())
+//                }
+//            }
+//
+//            context("without changing the `currentIndex`") {
+//                it("should contain 2 section") {
+//                    expect(segment.numberOfSections).to(equal(2))
+//                }
+//
+//                it("should set the delegate") {
+//                    expect(child1.updateDelegate).toNot(beNil())
+//                }
+//
+//                it("should not set the delegate of children") {
+//                    expect(child2.updateDelegate).to(beNil())
+//                }
+//
+//            }
+//        }
+//    }
+//
+//}


### PR DESCRIPTION
This is a major API change so is in a v2 branch. If we agree on a direction we could start adding PRs in to this branch.

This change would enable multiple changes to be applied at once, e.g. by requiring balanced calls to `mappingWillBeginUpdating` and `mappingDidEndUpdating` and only performing the updates when an equal number of `mappingDidEndUpdating` calls have been made. This could be a small performance improvement but would also improve animations.

By adding the `performUpdate` closure the changes to the model layer can be applied only when the consumer is expecting them, e.g. for `UICollectionView` this would be inside `performBatchUpdates` and would fix the existing crashes that occur when performing a change when there are pending layout changes.

Some tests and types have been commented out since this is more of a starting point for a discussion around the API than it is a solid implementation.

This is the closest I can see the API being (although it's still a breaking change) but maybe a bigger change would be better.

The biggest PITA is that the sections need to keep track of "current" data (e.g. what's being displayed by a collection view) and the "pending" data (e.g. what's about to be applied). I don't think this adds any memory overhead but it *does* add much more to the knowledge required when implementing a section.