### PR TITLE
Use default Xcode version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,9 @@ jobs:
   build_docs:
     name: Build Docs
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode: ["11.5"]
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,35 +4,11 @@ on: [push]
 
 jobs:
   xcode_tests:
-    name: ${{ matrix.platform }} Tests (Xcode ${{ matrix.xcode }})
+    name: Tests
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode: ["11.5"]
-        platform: ["iOS"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
-
-      - name: Cache SwiftPM
-        uses: actions/cache@v2
-        with:
-          path: CIDependencies/.build
-          key: ${{ runner.os }}-xcode_${{ matrix.xcode }}-swiftpm-ci-deps-${{ github.workspace }}-${{ hashFiles('CIDependencies/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-xcode_${{ matrix.xcode }}-swiftpm-ci-deps-${{ github.workspace }}
-
-      - name: Cache DerivedData
-        uses: actions/cache@v2
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-${{ matrix.platform }}_derived_data-xcode_${{ matrix.xcode }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}_derived_data
-
       - name: Run Tests
-        run: swift run --configuration release --skip-update --package-path ./CIDependencies/ xcutils test ${{ matrix.platform }} --scheme Composed --enable-code-coverage
+        run: swift run --configuration release --skip-update --package-path ./CIDependencies/ xcutils test iOS --scheme Composed --enable-code-coverage


### PR DESCRIPTION
In my open source frameworks I usually use the last major Xcode (currently 11.7), latest (currently 12.3) and latest beta (soon to be 12.4), but this project has only been setup for the latest version of Xcode.

If we feel it's good to run the tests across multiple Xcode versions I have created https://github.com/JosephDuffy/update-xcode-version-action, which we can use to keep the versions in-sync with the versions available as part of GitHub actions.

For now I've removed all use a explicit Xcode versions.