### PR TITLE
Cache `SingleElementSections.numberOfElements`

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/54D64DA2-CA29-4914-A042-3E433D613FF3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/54D64DA2-CA29-4914-A042-3E433D613FF3.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>SingleElementSectionTests</key>
+		<dict>
+			<key>testNumberOfElementsWithNonOptionalPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.013427</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testNumberOfElementsWithOptionalPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0137</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/D9B00B15-4839-46BA-A23F-CDD7A953C961.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/D9B00B15-4839-46BA-A23F-CDD7A953C961.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>SingleElementSectionTests</key>
+		<dict>
+			<key>testNumberOfElementsWithNonOptionalPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.112</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testNumberOfElementsWithOptionalPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.113</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/ComposedTests.xcbaseline/Info.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>54D64DA2-CA29-4914-A042-3E433D613FF3</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>8-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>3600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>iMac19,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,2</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+		<key>D9B00B15-4839-46BA-A23F-CDD7A953C961</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>8-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>3600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>iMac19,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/Composed/Sections/SingleElementSection.swift
+++ b/Sources/Composed/Sections/SingleElementSection.swift
@@ -19,17 +19,17 @@ open class SingleElementSection<Element>: Section {
     public private(set) var element: Element
 
     /// Generally returns 1, however if `element == Optional<Element>.none` returns 0
-    public var numberOfElements: Int {
-        switch element as Any {
-        case Optional<Any>.none: return 0
-        default: return 1
-        }
-    }
+    public private(set) var numberOfElements: Int
 
     /// Makes a `SingleElementSection` with the specified element
     /// - Parameter element: The element
     public init(element: Element) {
         self.element = element
+
+        switch element as Any {
+        case Optional<Any>.none: numberOfElements = 0
+        default: numberOfElements = 1
+        }
     }
 
     /// Replaces the element with the specified element
@@ -38,6 +38,11 @@ open class SingleElementSection<Element>: Section {
         updateDelegate?.willBeginUpdating(self)
         let wasEmpty = isEmpty
         self.element = element
+
+        switch element as Any {
+        case Optional<Any>.none: numberOfElements = 0
+        default: numberOfElements = 1
+        }
 
         switch (wasEmpty, isEmpty) {
         case (true, true):
@@ -51,5 +56,4 @@ open class SingleElementSection<Element>: Section {
         }
         updateDelegate?.didEndUpdating(self)
     }
-
 }

--- a/Tests/ComposedTests/SingleElementSectionTests.swift
+++ b/Tests/ComposedTests/SingleElementSectionTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Composed
+@testable import ComposedUI
+
+final class SingleElementSectionTests: XCTestCase {
+    func testNumberOfElementsWithOptional() {
+        let section = SingleElementSection<String?>(element: nil)
+
+        XCTAssertEqual(section.numberOfElements, 0)
+
+        section.replace(element: "")
+
+        XCTAssertEqual(section.numberOfElements, 1)
+
+        section.replace(element: .none)
+
+        XCTAssertEqual(section.numberOfElements, 0)
+    }
+
+    func testNumberOfElementsWithOptionalPerformance() {
+        let section = SingleElementSection<String?>(element: nil)
+
+        measure {
+            (0..<10_000).forEach { index in
+                if index % 2 != 0 {
+                    section.replace(element: String(describing: index))
+
+                    // When the element is set the delegate will likely call `numberOfElements` 1 or more times.
+                    // When the section itself is moved or otherwise queried `numberOfElements` is often called,
+                    // so it will usually be called more frequently than `replace(element:)`.
+                    (0..<10).forEach { _ in
+                        XCTAssertEqual(section.numberOfElements, 1)
+                    }
+                } else {
+                    section.replace(element: nil)
+
+                    (0..<10).forEach { _ in
+                        XCTAssertEqual(section.numberOfElements, 0)
+                    }
+                }
+            }
+        }
+    }
+
+    func testNumberOfElementsWithNonOptionalPerformance() {
+        let section = SingleElementSection<String>(element: "")
+
+        measure {
+            (0..<10_000).forEach { index in
+                section.replace(element: String(describing: index))
+
+                (0..<10).forEach { _ in
+                    XCTAssertEqual(section.numberOfElements, 1)
+                }
+            }
+        }
+    }
+}

--- a/Tests/ComposedTests/SingleElementSectionTests.swift
+++ b/Tests/ComposedTests/SingleElementSectionTests.swift
@@ -1,6 +1,5 @@
 import XCTest
-import Composed
-@testable import ComposedUI
+@testable import Composed
 
 final class SingleElementSectionTests: XCTestCase {
     func testNumberOfElementsWithOptional() {


### PR DESCRIPTION
Overall this is pretty minor but when dealing with a lot of `SingleElementSections` that are infrequently updated is does start to slow down.

I thought a faster approach would be to use generics on `replace(element:)` to only check for `nil` when the value is `Optional`, but generics don't allow for this kind of overload.

Also added some basic tests. The performance tests show a ~9% performance increase.