### PR TITLE
Correctly calculate `CollectionFlowLayoutEnvironment.contentSize`

### DIFF
--- a/Sources/ComposedLayouts/CollectionCoordinator+FlowLayout.swift
+++ b/Sources/ComposedLayouts/CollectionCoordinator+FlowLayout.swift
@@ -16,8 +16,9 @@ extension CollectionCoordinator: UICollectionViewDelegateFlowLayout {
     }
 
     private func environment(collectionView: UICollectionView, layout: UICollectionViewFlowLayout) -> CollectionFlowLayoutEnvironment {
-        let size = collectionView.bounds.insetBy(dx: layout.sectionInset.left + layout.sectionInset.right, dy: 0).size
-        return CollectionFlowLayoutEnvironment(contentSize: size, traitCollection: collectionView.traitCollection)
+        var contentSize = collectionView.bounds.size
+        contentSize.width -= collectionView.contentInset.left + collectionView.contentInset.right
+        return CollectionFlowLayoutEnvironment(contentSize: contentSize, traitCollection: collectionView.traitCollection)
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {


### PR DESCRIPTION
Here's a small PR for a bug that I think has just gone unnoticed because we've never used the `sectionInset` property of the `UICollectionViewFlowLayout`, and we've never used the `contentInset` property of `UICollectionView`.

The issues looks to be that the layout's `sectionInset` property is applied on a per-section basis, but the collection view's `contentInset` was not being honoured.

It was also calculated using `insetBy(dx:dy:)`, which will modify the width by `-dx * 2`, which would double the expected insets.